### PR TITLE
Rename disk space job to make it clearer for CMS users

### DIFF
--- a/src/Jobs/DiskSpaceJob.php
+++ b/src/Jobs/DiskSpaceJob.php
@@ -30,7 +30,7 @@ class DiskSpaceJob extends AbstractQueuedJob
 
     public function getTitle(): string
     {
-        return 'Disk space job';
+        return 'Compile disk space report';
     }
 
     public function process(): void


### PR DESCRIPTION
'Disk space job' suggests to me that something is _creating_ disk space, not reporting on it.